### PR TITLE
Update Project Year to 2024

### DIFF
--- a/.wpilib/wpilib_preferences.json
+++ b/.wpilib/wpilib_preferences.json
@@ -1,6 +1,6 @@
 {
     "enableCppIntellisense": false,
     "currentLanguage": "java",
-    "projectYear": "2024beta",
+    "projectYear": "2024",
     "teamNumber": 492
 }


### PR DESCRIPTION
This stops wpilib prompted the user that the project is incompatible and to import the project.